### PR TITLE
chore: update to alpine 3.18 for pdns 4.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.16
+FROM docker.io/alpine:3.18
 ARG VERSION
 RUN apk --no-cache add \
     pdns=${VERSION} \


### PR DESCRIPTION
Update PowerDNS to 4.7.4-r0. After this is merged, we need to tag and push that version.
